### PR TITLE
Fix code scanning alert no. 1: Flask app is run in debug mode

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ import pymysql
 import config
 from werkzeug.security import generate_password_hash, check_password_hash
 import logging
+import os
 
 # Set up logging
 logging.basicConfig(level=logging.INFO)
@@ -191,4 +192,5 @@ def logout():
 
 # Function to run the Flask app
 if __name__ == '__main__':
-    app.run(debug=True)
+    debug_mode = os.getenv('FLASK_ENV') == 'development'
+    app.run(debug=debug_mode)


### PR DESCRIPTION
Fixes [https://github.com/hutcch0/chatroom-website/security/code-scanning/1](https://github.com/hutcch0/chatroom-website/security/code-scanning/1)

To fix the problem, we need to ensure that the Flask application does not run in debug mode in a production environment. This can be achieved by using environment variables to control the debug mode. Specifically, we can use the `FLASK_ENV` environment variable to determine whether the application should run in development or production mode.

1. Modify the `app.run()` call to check the environment variable and set `debug` accordingly.
2. Import the `os` module to access environment variables.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
