### PR TITLE
Fix code scanning alert no. 3: Information exposure through an exception

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,7 +4,7 @@ import config
 from werkzeug.security import generate_password_hash, check_password_hash
 import logging
 import os
-
+import traceback
 # Set up logging
 logging.basicConfig(level=logging.INFO)
 
@@ -122,14 +122,16 @@ def about():
     try:
         return render_template('about.html')
     except Exception as e:
-        return str(e), 500
+        logging.error(f"Error rendering about page: {traceback.format_exc()}")
+        return "An internal error has occurred!", 500
 
 @app.route('/news')
 def news():
     try:
         return render_template('news.html')
     except Exception as e:
-        return str(e), 500
+        logging.error(f"Error rendering news page: {traceback.format_exc()}")
+        return "An internal error has occurred!", 500
 
 @app.route('/chatroom')
 def chatroom_page():


### PR DESCRIPTION
Fixes [https://github.com/hutcch0/chatroom-website/security/code-scanning/3](https://github.com/hutcch0/chatroom-website/security/code-scanning/3)

To fix the problem, we need to ensure that detailed exception information is not exposed to the end user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by modifying the exception handling in the `/about` and `/news` routes.

1. Import the `traceback` module to capture the stack trace.
2. Log the detailed error message using the `logging` module.
3. Return a generic error message to the user.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
