### PR TITLE
Fix code scanning alert no. 4: Flask app is run in debug mode

### DIFF
--- a/image_server.py
+++ b/image_server.py
@@ -12,5 +12,7 @@ def uploaded_file(filename):
 
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    import os
+    debug_mode = os.getenv('FLASK_DEBUG', '0') == '1'
+    app.run(debug=debug_mode)
   # Use debug=False for production


### PR DESCRIPTION
Fixes [https://github.com/hutcch0/chatroom-website/security/code-scanning/4](https://github.com/hutcch0/chatroom-website/security/code-scanning/4)

To fix the problem, we need to ensure that the Flask application does not run in debug mode when deployed in a production environment. The best way to achieve this is to use an environment variable to control the debug mode. This way, the application can run in debug mode during development and switch to production mode without modifying the code.

We will modify the `app.run()` call to check the value of an environment variable (e.g., `FLASK_DEBUG`). If the environment variable is set to '1', the application will run in debug mode; otherwise, it will run with debug mode disabled.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
